### PR TITLE
Backport Python3 compatibility from pyrocko

### DIFF
--- a/gmtpy.py
+++ b/gmtpy.py
@@ -21,7 +21,6 @@ import re
 import os
 import sys
 import shutil
-from itertools import izip
 from os.path import join as pjoin
 import tempfile
 import random
@@ -3068,7 +3067,7 @@ class TableLiner:
 
     def __iter__(self):
         if self.in_columns is not None:
-            for row in izip(*self.in_columns):
+            for row in zip(*self.in_columns):
                 yield ' '.join([str(x) for x in row])+'\n'
 
         if self.in_rows is not None:

--- a/gmtpy.py
+++ b/gmtpy.py
@@ -1487,7 +1487,7 @@ def loadgrd(filename):
     from scipy.io import netcdf
 
     nc = netcdf.netcdf_file(filename, 'r')
-    vkeys = nc.variables.keys()
+    vkeys = list(nc.variables.keys())
     kx = 'x'
     ky = 'y'
     if 'lon' in vkeys:

--- a/gmtpy.py
+++ b/gmtpy.py
@@ -299,18 +299,16 @@ _gmt_installations = {}
 # ... or let GmtPy autodetect GMT via $PATH and $GMTHOME
 
 
-def cmp_version(a, b):
-    ai = [int(x) for x in a.split('.')]
-    bi = [int(x) for x in b.split('.')]
-    return cmp(ai, bi)
+def key_version(a):
+    return tuple(int(x) for x in a.split('.'))
 
 
 def newest_installed_gmt_version():
-    return sorted(_gmt_installations.keys(), cmp=cmp_version)[-1]
+    return sorted(_gmt_installations.keys(), key=key_version)[-1]
 
 
 def all_installed_gmt_versions():
-    return sorted(_gmt_installations.keys(), cmp=cmp_version)
+    return sorted(_gmt_installations.keys(), key=key_version)
 
 
 # To have consistent defaults, they are hardcoded here and should not be
@@ -1202,13 +1200,12 @@ def detect_gmt_installations():
 
 def appropriate_defaults_version(version):
 
-    avails = sorted(_gmt_defaults_by_version.keys(), cmp=cmp_version)
+    avails = sorted(_gmt_defaults_by_version.keys(), key=key_version)
     for iavail, avail in enumerate(avails):
-        c = cmp_version(version, avail)
-        if c == 0:
+        if key_version(version) == key_version(avail):
             return version
 
-        elif c == -1:
+        elif key_version(version) < key_version(avail):
             return avails[max(0, iavail-1)]
 
     return avails[-1]

--- a/gmtpy.py
+++ b/gmtpy.py
@@ -1638,7 +1638,7 @@ def doublegrid(x, y, z):
     return x2, y2, z2
 
 
-class Guru:
+class Guru(object):
     '''Abstract base class providing template interpolation, accessible as
     attributes.
 
@@ -1712,7 +1712,7 @@ def nice_value(x):
     return sign * 0.1 * exp
 
 
-class AutoScaler:
+class AutoScaler(object):
     '''Tunable 1D autoscaling based on data range.
 
     Instances of this class may be used to determine nice minima, maxima and
@@ -2212,7 +2212,7 @@ class ScaleGuru(Guru):
         return params
 
 
-class GumSpring:
+class GumSpring(object):
 
     '''Sizing policy implementing a minimal size, plus a desire to grow.'''
 
@@ -3058,7 +3058,7 @@ def text_box(
     return dx, dy
 
 
-class TableLiner:
+class TableLiner(object):
     '''Utility class to turn tables into lines.'''
 
     def __init__(self, in_columns=None, in_rows=None):
@@ -3075,7 +3075,7 @@ class TableLiner:
                 yield ' '.join([str(x) for x in row])+'\n'
 
 
-class LineStreamChopper:
+class LineStreamChopper(object):
     '''File-like object to buffer data.'''
 
     def __init__(self, liner):
@@ -3132,7 +3132,7 @@ font_tab = {
 font_tab_rev = dict((v, k) for (k, v) in font_tab.items())
 
 
-class GMT:
+class GMT(object):
     '''A thin wrapper to GMT command execution.
 
     A dict ``config`` may be given to override some of the default GMT
@@ -3774,7 +3774,7 @@ def simpleconf_to_ax(conf, axname):
     return Ax(**c)
 
 
-class DensityPlotDef:
+class DensityPlotDef(object):
     def __init__(self, data, cpt='ocean', tension=0.7, size=(640, 480),
                  contour=False, method='surface', zscaler=None, **extra):
         self.data = data
@@ -3787,7 +3787,7 @@ class DensityPlotDef:
         self.extra = extra
 
 
-class TextDef:
+class TextDef(object):
     def __init__(
             self,
             data,
@@ -3805,7 +3805,7 @@ class TextDef:
         self.color = color
 
 
-class Simple:
+class Simple(object):
     def __init__(self, gmtconfig=None, gmtversion='newest', **simple_config):
         self.data = []
         self.symbols = []

--- a/gmtpy.py
+++ b/gmtpy.py
@@ -14,6 +14,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+from __future__ import print_function
 import subprocess
 from cStringIO import StringIO
 import re
@@ -1241,15 +1242,15 @@ def diff_defaults(v1, v2):
     d2 = gmt_default_config(v2)
     for k in d1:
         if k not in d2:
-            print '%s not in %s' % (k, v2)
+            print('%s not in %s' % (k, v2))
         else:
             if d1[k] != d2[k]:
-                print '%s %s = %s' % (v1, k, d1[k])
-                print '%s %s = %s' % (v2, k, d2[k])
+                print('%s %s = %s' % (v1, k, d1[k]))
+                print('%s %s = %s' % (v2, k, d2[k]))
 
     for k in d2:
         if k not in d1:
-            print '%s not in %s' % (k, v1)
+            print('%s not in %s' % (k, v1))
 
 # diff_defaults('4.5.2', '4.5.3')
 

--- a/gmtpy.py
+++ b/gmtpy.py
@@ -1301,7 +1301,7 @@ def setup_gmt_installations():
             _gmt_installations.update(detect_gmt_installations())
 
         # store defaults as dicts into the gmt installations dicts
-        for version, installation in _gmt_installations.iteritems():
+        for version, installation in _gmt_installations.items():
             installation['defaults'] = gmt_default_config(version)
             installation['version'] = version
 
@@ -3129,7 +3129,7 @@ font_tab = {
     1: 'Helvetica-Bold',
 }
 
-font_tab_rev = dict((v, k) for (k, v) in font_tab.iteritems())
+font_tab_rev = dict((v, k) for (k, v) in font_tab.items())
 
 
 class GMT:
@@ -3253,7 +3253,7 @@ class GMT:
         f = open(config_filename, 'w')
         f.write('#\n# GMT %s Defaults file\n' % self.installation['version'])
 
-        for k, v in config.iteritems():
+        for k, v in config.items():
             f.write('%s = %s\n' % (k, v))
         f.close()
 

--- a/gmtpy.py
+++ b/gmtpy.py
@@ -3108,7 +3108,7 @@ class LineStreamChopper(object):
 
         self.chopsize = size
         try:
-            return self.chop_iterator.next()
+            return next(self.chop_iterator)
         except StopIteration:
             return ''
 


### PR DESCRIPTION
This pull request brings the syntax changes required for compatibility between Python 2 and Python 3.

I started doing these changes by myself to later realise that `gmtpy` is already ported to Python 3 inside `pyrocko`. So in the end I just collected the specific changes from the `pyrocko` version that are related to the Python 3 compatibility.